### PR TITLE
Feature image cut

### DIFF
--- a/js/format_image/index.js
+++ b/js/format_image/index.js
@@ -1,0 +1,44 @@
+const sh = require('shelljs');
+const fs = require('fs');
+const {Log} = require('../util');
+
+var dirname = process.cwd() + '/';
+
+// image size
+var size_array = [
+    "16", "512", "60", "120", "72",
+    "144", "76", "152", "32", "48",
+    "96", "29", "58", "40", "80",
+    "50", "100", "57"
+]
+
+function init(dir, filename) {
+    if(!filename || !fs.existsSync(filename)) {
+        Log.error('无法定位至文件');
+        process.exit(1);
+    }
+
+    var suffixReg = /\.[^.]+$/, m_dir = '';
+
+    dirname = dir ? dirname + dir : dirname + 'logo';
+
+    var suffix = suffixReg.exec(filename);
+
+    if (!fs.existsSync(dir)) {
+        sh.exec('mkdir ' + dirname );
+    }
+
+    for(var i=0, len=size_array.length; i<len; i++){
+        m_dir = dirname + '/' + size_array[i] + suffix;
+
+        sh.exec('cp ' + filename + ' ' + m_dir);
+        sh.exec('sips -Z ' + size_array[i] + ' ' + m_dir);
+    }
+
+    process.on('exit', function () {
+        Log.info('图片格式化完成!');
+        console.log('gmfe exit');
+    });
+}
+
+module.exports = init;

--- a/js/format_image/index.js
+++ b/js/format_image/index.js
@@ -13,7 +13,7 @@ var size_array = [
 ]
 
 function init(dir, filename) {
-    if(!filename || !fs.existsSync(filename)) {
+    if(!fs.existsSync(filename)) {
         Log.error('无法定位至文件');
         process.exit(1);
     }

--- a/js/format_image/index.js
+++ b/js/format_image/index.js
@@ -24,8 +24,8 @@ function init(dir, filename) {
 
     var suffix = suffixReg.exec(filename);
 
-    if (!fs.existsSync(dir)) {
-        sh.exec('mkdir ' + dirname );
+    if (!fs.existsSync(dirname)) {
+        sh.exec('mkdir ' + dirname);
     }
 
     for(var i=0, len=size_array.length; i<len; i++){

--- a/js/help.js
+++ b/js/help.js
@@ -9,7 +9,7 @@ function help() {
             command: 'versioninfo',
             desc: 'show recently version'
         })
-        .command('format', 'format image')
+        .command('imagecut', 'image cut')
         .demandCommand()
         .option('u', {
             alias: 'user',
@@ -33,10 +33,6 @@ function help() {
             alias: 'dir',
             demand: false,
             describe: 'where the image will be generated'
-        }).option('f', {
-            alias: 'file',
-            demand: false,
-            describe: 'source image file path'
         })
         .example('' +
             'gmfe publish -u name\n' +
@@ -44,7 +40,7 @@ function help() {
             'gmfe publish -u name -b release-xxx\n' +
             'gmfe test -b release-xxx\n' +
             'gmfe versioninfo\n' +
-            'gmfe format -f ./logo.png -d logo')
+            'gmfe imagecut ./js/logo.jpg -d ./img')
         .version()
         .argv;
 }

--- a/js/help.js
+++ b/js/help.js
@@ -9,6 +9,7 @@ function help() {
             command: 'versioninfo',
             desc: 'show recently version'
         })
+        .command('format', 'format image')
         .demandCommand()
         .option('u', {
             alias: 'user',
@@ -28,8 +29,22 @@ function help() {
             alias: 'week',
             demand: false,
             describe: 'how many weeks to show'
+        }).option('d', {
+            alias: 'dir',
+            demand: false,
+            describe: 'where the image will be generated'
+        }).option('f', {
+            alias: 'file',
+            demand: false,
+            describe: 'source image file path'
         })
-        .example('gmfe publish -u name\ngmfe publish -u name -t online_2017_08_21_17_50_name\ngmfe publish -u name -b release-xxx\ngmfe test -b release-xxx\ngmfe versioninfo')
+        .example('' +
+            'gmfe publish -u name\n' +
+            'gmfe publish -u name -t online_2017_08_21_17_50_name\n' +
+            'gmfe publish -u name -b release-xxx\n' +
+            'gmfe test -b release-xxx\n' +
+            'gmfe versioninfo\n' +
+            'gmfe format -f ./logo.png -d logo')
         .version()
         .argv;
 }

--- a/js/image_cut/index.js
+++ b/js/image_cut/index.js
@@ -20,11 +20,9 @@ function init(dir, filename) {
     }
 
     var suffixReg = /\.[^.]+$/, m_dir = '';
+    var suffix = suffixReg.exec(filename);
 
     dirname = path.resolve(root,  dir ? dir : './logo');
-
-
-    var suffix = suffixReg.exec(filename);
 
     if (!fs.existsSync(dirname)) {
         sh.exec('mkdir ' + dirname);

--- a/js/image_cut/index.js
+++ b/js/image_cut/index.js
@@ -36,7 +36,7 @@ function init(dir, filename) {
     }
 
     process.on('exit', function () {
-        Log.info('图片格式化完成!');
+        Log.info('图片裁剪完成!');
         console.log('gmfe exit');
     });
 }

--- a/js/image_cut/index.js
+++ b/js/image_cut/index.js
@@ -32,7 +32,7 @@ function init(dir, filename) {
         m_dir = dirname + '/' + size_array[i] + suffix;
 
         sh.exec('cp ' + filename + ' ' + m_dir);
-        sh.exec('sips -Z ' + size_array[i] + ' ' + m_dir);
+        sh.exec('sips -Z ' + size_array[i] + ' ' + m_dir,  { silent: true });
     }
 
     process.on('exit', function () {

--- a/js/image_cut/index.js
+++ b/js/image_cut/index.js
@@ -1,8 +1,9 @@
 const sh = require('shelljs');
 const fs = require('fs');
 const {Log} = require('../util');
+const path = require('path');
 
-var dirname = process.cwd() + '/';
+var root = process.cwd();
 
 // image size
 var size_array = [
@@ -20,7 +21,8 @@ function init(dir, filename) {
 
     var suffixReg = /\.[^.]+$/, m_dir = '';
 
-    dirname = dir ? dirname + dir : dirname + 'logo';
+    dirname = path.resolve(root,  dir ? dir : './logo');
+
 
     var suffix = suffixReg.exec(filename);
 

--- a/js/index.js
+++ b/js/index.js
@@ -3,7 +3,7 @@ const help = require('./help');
 const publishInit = require('./publish/index');
 const testInit = require('./test/index');
 const versionInfo = require('./version_info/index');
-const formatImage = require('./format_image/index');
+const imageCut = require('./image_cut/index');
 
 // help 信息
 const argv = help();
@@ -20,8 +20,8 @@ if (argv._.includes('publish') && argv.u) {
     testInit(argv.b);
 } else if (argv._.includes('versioninfo')) {
     versionInfo(argv.w);
-} else if (argv._.includes('format')) {
-    formatImage(argv.d, argv.f);
+} else if (argv._.includes('imagecut')) {
+    imageCut(argv.d, argv._[1]);
 }else {
     sh.exec('gmfe -h');
     process.exit(0);

--- a/js/index.js
+++ b/js/index.js
@@ -3,6 +3,7 @@ const help = require('./help');
 const publishInit = require('./publish/index');
 const testInit = require('./test/index');
 const versionInfo = require('./version_info/index');
+const formatImage = require('./format_image/index');
 
 // help 信息
 const argv = help();
@@ -19,7 +20,9 @@ if (argv._.includes('publish') && argv.u) {
     testInit(argv.b);
 } else if (argv._.includes('versioninfo')) {
     versionInfo(argv.w);
-} else {
+} else if (argv._.includes('format')) {
+    formatImage(argv.d, argv.f);
+}else {
     sh.exec('gmfe -h');
     process.exit(0);
 }


### PR DESCRIPTION
### 1、功能
将图片格式化以下大小格式图片
```
var size_array = [
    "16", "512", "60", "120", "72",
    "144", "76", "152", "32", "48",
    "96", "29", "58", "40", "80",
    "50", "100", "57"
]
```
格式化的图片命名以上面的数字命名。
***

### 2、实现

*参数*
`-f` 将要格式的图片的目录，比如 ‘./guanmai/gmfe/hello.jpg’，必须值，否则`Log.error('无法定位至文件');`
`-d` 格式后图片将会在此目录生成， 非必须，不传的话默认是 ‘logo’ 文件夹名

*存放格式化后的图片的文件的目录位置*
以执行该脚本时的目录为根目录

*example*
执行 `gmfe format -f ./image/logo.png -d image`  将会把 `./image/logo.png` 图片格式化成多种格式，并生成在与执行该脚本时的目录同级的 `image` 目录

### 3、附
[sips命令处理图片](http://zqpythonic.qiniucdn.com/data/20151206235027/index.html)