### PR TITLE
完善代码/命令

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,11 @@
 module.exports = {
-    "plugins": [
-        "gm"
-    ],
-    "extends": ["plugin:gm/recommended"],
-    "rules": {
-        "react/no-string-refs": 0,
-        "react/no-deprecated": 0
-    }
-};
+  'parser': 'babel-eslint',
+  'extends': [
+    'standard',
+    'standard-jsx'
+  ],
+  'rules': {
+    'react/jsx-tag-spacing': ['error', {'beforeSelfClosing': 'never'}],
+    'camelcase': 0
+  }
+}

--- a/bin/gmfe.js
+++ b/bin/gmfe.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../js/index');
+require('../js/index')

--- a/js/common/confirm.js
+++ b/js/common/confirm.js
@@ -1,33 +1,20 @@
-const logger = require('../util').logger;
-const readline = require('readline');
+const inquirer = require('inquirer')
 
-function confirm(action) {
-    logger.info(`>>>>>>>>>> 确认是否${action}`);
-
-    const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
-
-    const question = function (callback) {
-        rl.question(`Are you sure to ${action}?(yes|no) `, function (answer) {
-            if (answer === 'yes' || answer === 'no') {
-                rl.close();
-                callback(answer);
-            } else {
-                question(callback);
-            }
-        });
-    };
-    return new Promise(function (resolve, reject) {
-        question(function (answer) {
-            if (answer === 'yes') {
-                resolve();
-            } else {
-                reject();
-            }
-        });
-    });
+async function confirm (action) {
+  let result = await inquirer.prompt({
+    type: 'input',
+    name: action,
+    message: `确认是否${action}(yes/no)`,
+    validate (input) {
+      if (input !== 'yes' && input !== 'no') {
+        return 'please input yes or no'
+      }
+      return true
+    }
+  })
+  if (result[action] === 'no') {
+    process.exit(0)
+  }
 }
 
-module.exports = confirm;
+module.exports = confirm

--- a/js/common/confirm.js
+++ b/js/common/confirm.js
@@ -4,7 +4,7 @@ async function confirm (action) {
   let result = await inquirer.prompt({
     type: 'input',
     name: action,
-    message: `确认是否${action}(yes/no)`,
+    message: `确认是否 ${action} (yes/no)`,
     validate (input) {
       if (input !== 'yes' && input !== 'no') {
         return 'please input yes or no'

--- a/js/common/preview.js
+++ b/js/common/preview.js
@@ -1,0 +1,30 @@
+const sh = require('./shelljs_wrapper')
+const Util = require('../util')
+const { getCurrentBranch, verifyBranch } = Util
+const logger = require('../logger')
+
+function preview (testBranch) {
+  logger.info('检测本地代码状态')
+  const diff = sh.exec('git diff', { silent: true })
+  if (diff.stdout !== '') {
+    logger.fatal('Dirty！确保你本地代码是干净的')
+  }
+
+  let curBranch = getCurrentBranch()
+  if (curBranch !== 'master') {
+    sh.exec('git checkout master')
+    curBranch = 'master'
+  }
+
+  logger.info('拉远端代码')
+  sh.exec('git pull') // master目录有全部的远端分支
+  verifyBranch(testBranch)
+
+  logger.info('比较远端代码')
+  const oDiff = sh.exec(`git diff ${curBranch} origin/${curBranch}`, { silent: true })
+  if (oDiff.stdout !== '') {
+    logger.fatal(`${curBranch}不同于origin/${curBranch}。请检查！`)
+  }
+}
+
+module.exports = preview

--- a/js/common/preview.js
+++ b/js/common/preview.js
@@ -3,11 +3,11 @@ const Util = require('../util')
 const { getCurrentBranch, verifyBranch } = Util
 const logger = require('../logger')
 
-function preview (testBranch) {
+function preview (previewBranch) {
   logger.info('检测本地代码状态')
   const diff = sh.exec('git diff', { silent: true })
   if (diff.stdout !== '') {
-    logger.fatal('Dirty！确保你本地代码是干净的')
+    logger.fatalAndExit('Dirty！确保你本地代码是干净的')
   }
 
   let curBranch = getCurrentBranch()
@@ -18,12 +18,12 @@ function preview (testBranch) {
 
   logger.info('拉远端代码')
   sh.exec('git pull') // master目录有全部的远端分支
-  verifyBranch(testBranch)
+  verifyBranch(previewBranch)
 
   logger.info('比较远端代码')
   const oDiff = sh.exec(`git diff ${curBranch} origin/${curBranch}`, { silent: true })
   if (oDiff.stdout !== '') {
-    logger.fatal(`${curBranch}不同于origin/${curBranch}。请检查！`)
+    logger.fatalAndExit(`${curBranch}不同于origin/${curBranch}。请检查！`)
   }
 }
 

--- a/js/common/shelljs_wrapper.js
+++ b/js/common/shelljs_wrapper.js
@@ -4,7 +4,13 @@ const logger = require('../logger')
 let extra = {
   cd (destPath) {
     logger.info('切换目录', destPath)
-    sh.cd(destPath)
+    const execResult = sh.cd(destPath)
+    if (execResult.code !== 0) {
+      const msg = execResult.stderr
+      logger.error(`路径【${destPath}】错误 \n${msg}`)
+      throw new Error('')
+    }
+    return execResult
   },
   exec (command, options = {}) {
     logger.info('执行命令', command)

--- a/js/common/shelljs_wrapper.js
+++ b/js/common/shelljs_wrapper.js
@@ -1,0 +1,25 @@
+const sh = require('shelljs')
+const logger = require('../logger')
+
+let extra = {
+  cd (destPath) {
+    logger.info('切换目录', destPath)
+    sh.cd(destPath)
+  },
+  exec (command, options = {}) {
+    logger.info('执行命令', command)
+    const execResult = sh.exec(command, options)
+    if (execResult.code !== 0) {
+      const msg = execResult.stderr
+      logger.error(`【${command}】执行出错 \n${msg}`)
+      throw new Error('')
+    }
+    return execResult
+  }
+}
+
+module.exports = Object.assign(
+  {},
+  sh,
+  extra
+)

--- a/js/help.js
+++ b/js/help.js
@@ -1,51 +1,51 @@
-const yargs = require('yargs');
+const yargs = require('yargs')
 
-function help() {
-    return yargs.usage('gmfe publish [options]')
-        .locale('en')
-        .command('publish', 'publish project')
-        .command('test', 'test project')
-        .command({
-            command: 'versioninfo',
-            desc: 'show recently version'
-        })
-        .command('imagecut', 'image cut')
-        .command('renametoen', 'rename to en')
-        .command('npm_publish', 'publish a package to npm and sync to taobao')
-        .command('icon_publish', 'add icon to gm-xfont and publish gm-xfont to npm')
-        .demandCommand()
-        .option('u', {
-            alias: 'user',
-            demand: false,
-            describe: 'name who publish project',
-            type: 'string'
-        }).option('t', {
-            alias: 'tag',
-            demand: false,
-            describe: 'which tag to rollback',
-            type: 'string'
-        }).option('b', {
-            alias: 'branch',
-            demand: false,
-            describe: 'which branch to gray or test release'
-        }).option('w', {
-            alias: 'week',
-            demand: false,
-            describe: 'how many weeks to show'
-        }).option('d', {
-            alias: 'dir',
-            demand: false,
-            describe: 'where the image will be generated'
-        }).option('a', {
-            alias: 'add',
-            demand: false,
-            describe: 'npm version major or minor or patch'
-        }).option('m', {
-            alias: 'message',
-            demand: false,
-            describe: 'commit message or comment'
-        })
-        .example('' +
+function help () {
+  return yargs.usage('gmfe publish [options]')
+    .locale('en')
+    .command('publish', 'publish project')
+    .command('test', 'test project')
+    .command({
+      command: 'versioninfo',
+      desc: 'show recently version'
+    })
+    .command('imagecut', 'image cut')
+    .command('renametoen', 'rename to en')
+    .command('npm_publish', 'publish a package to npm and sync to taobao')
+    .command('icon_publish', 'add icon to gm-xfont and publish gm-xfont to npm')
+    .demandCommand()
+    .option('u', {
+      alias: 'user',
+      demand: false,
+      describe: 'name who publish project',
+      type: 'string'
+    }).option('t', {
+      alias: 'tag',
+      demand: false,
+      describe: 'which tag to rollback',
+      type: 'string'
+    }).option('b', {
+      alias: 'branch',
+      demand: false,
+      describe: 'which branch to gray or test release'
+    }).option('w', {
+      alias: 'week',
+      demand: false,
+      describe: 'how many weeks to show'
+    }).option('d', {
+      alias: 'dir',
+      demand: false,
+      describe: 'where the image will be generated'
+    }).option('a', {
+      alias: 'add',
+      demand: false,
+      describe: 'npm version major or minor or patch'
+    }).option('m', {
+      alias: 'message',
+      demand: false,
+      describe: 'commit message or comment'
+    })
+    .example('' +
             'gmfe publish -u name\n' +
             'gmfe publish -u name -t online_2017_08_21_17_50_name\n' +
             'gmfe publish -u name -b release-xxx\n' +
@@ -59,9 +59,9 @@ function help() {
             'gmfe renametoen\n' +
             'gmfe renametoen ./images ./rename\n' +
             'gmfe renametoen ./name.txt ./rename.txt'
-        )
-        .version()
-        .argv;
+    )
+    .version()
+    .argv
 }
 
-module.exports = help;
+module.exports = help

--- a/js/icon_publish/index.js
+++ b/js/icon_publish/index.js
@@ -1,40 +1,35 @@
-const sh = require('shelljs');
-const {logger, getProjectPath, getPackageJSON, getBranchName} = require('../util');
-const npm_publish = require('../npm_publish');
+const sh = require('../common/shelljs_wrapper')
+const {getProjectPath, getPackageJSON, getCurrentBranch} = require('../util')
+const logger = require('../logger')
+const npm_publish = require('../npm_publish')
+const fs = require('fs')
 
 const _init = (filePath, commit = '新增icon') => {
-    const projectPath = getProjectPath();
-    if(projectPath === false) {
-        logger.err('无法定位git工程');
-        process.exit(1);
-    }
+  const projectPath = getProjectPath()
 
-    const packageJSON = getPackageJSON();
-    if(packageJSON.name !== 'gm-xfont') {
-        logger.err('当前工程不是gm-xfont');
-        process.exit(1);
-    }
+  const packageJSON = getPackageJSON()
+  if (packageJSON.name !== 'gm-xfont') {
+    logger.fatal('当前工程不是gm-xfont')
+  }
 
-    if(/\.zip$/.test(filePath) === false) {
-        logger.err('请确认icon压缩包路径');
-        process.exit(1);
-    }
-    sh.exec('git pull');
-    // icon包解压到工程目录,覆盖
-    sh.exec('unzip -o -j -d ' + projectPath + ' ' + filePath);
-    logger.info('解压完毕');
+  if (!fs.existsSync(filePath)) {
+    logger.fatal('请确认icon压缩包路径')
+  }
+  sh.exec('git pull')
+  // icon包解压到工程目录,覆盖
+  sh.exec('unzip -o -j -d ' + projectPath + ' ' + filePath)
+  logger.info('解压完毕')
 
-    // master
-    const currentBranch = getBranchName();
-    if (!currentBranch === 'master') {
-        logger.warn('确保你处于master分支');
-        process.exit(1);
-    }
+  // master
+  const currentBranch = getCurrentBranch()
+  if (currentBranch !== 'master') {
+    logger.fatal('确保你处于master分支')
+  }
 
-    logger.info('正在推送代码到origin...');
-    sh.exec('git add . && git commit -m ' + commit + ' && git push origin master:master;');
+  logger.info('正在推送代码到origin...')
+  sh.exec('git add . && git commit -m ' + commit + ' && git push origin master:master;')
 
-    npm_publish('patch');
-};
+  npm_publish('patch')
+}
 
-module.exports = _init;
+module.exports = _init

--- a/js/image_cut/index.js
+++ b/js/image_cut/index.js
@@ -1,45 +1,45 @@
-const sh = require('shelljs');
-const fs = require('fs');
-const { logger } = require('../util');
-const path = require('path');
+const sh = require('../common/shelljs_wrapper')
+const fs = require('fs')
+const { logger } = require('../util')
+const path = require('path')
 
-const root = process.cwd();
+const root = process.cwd()
 
 // image size
 const size_array = [
-    "16", "512", "60", "120", "72",
-    "144", "76", "152", "32", "48",
-    "96", "29", "58", "40", "80",
-    "50", "100", "57"
-];
+  '16', '512', '60', '120', '72',
+  '144', '76', '152', '32', '48',
+  '96', '29', '58', '40', '80',
+  '50', '100', '57'
+]
 
-function init(dir, filename) {
-    if (!fs.existsSync(filename)) {
-        logger.error('无法定位至文件');
-        process.exit(1);
-    }
+function init (dir, filename) {
+  if (!fs.existsSync(filename)) {
+    logger.error('无法定位至文件')
+    process.exit(1)
+  }
 
-    const suffixReg = /\.[^.]+$/;
-    const suffix = suffixReg.exec(filename);
-    let m_dir = '';
+  const suffixReg = /\.[^.]+$/
+  const suffix = suffixReg.exec(filename)
+  let m_dir = ''
 
-    const dirname = path.resolve(root, dir ? dir : './logo');
+  const dirname = path.resolve(root, dir || './logo')
 
-    if (!fs.existsSync(dirname)) {
-        sh.exec('mkdir ' + dirname);
-    }
+  if (!fs.existsSync(dirname)) {
+    sh.exec('mkdir ' + dirname)
+  }
 
-    for (var i = 0, len = size_array.length; i < len; i++) {
-        m_dir = dirname + '/' + size_array[i] + suffix;
+  for (var i = 0, len = size_array.length; i < len; i++) {
+    m_dir = dirname + '/' + size_array[i] + suffix
 
-        sh.exec('cp ' + filename + ' ' + m_dir);
-        sh.exec('sips -Z ' + size_array[i] + ' ' + m_dir, { silent: true });
-    }
+    sh.exec('cp ' + filename + ' ' + m_dir)
+    sh.exec('sips -Z ' + size_array[i] + ' ' + m_dir, { silent: true })
+  }
 
-    process.on('exit', function () {
-        logger.info('图片裁剪完成!');
-        logger.info('gmfe exit');
-    });
+  process.on('exit', function () {
+    logger.info('图片裁剪完成!')
+    logger.info('gmfe exit')
+  })
 }
 
-module.exports = init;
+module.exports = init

--- a/js/index.js
+++ b/js/index.js
@@ -1,58 +1,40 @@
-const sh = require("shelljs");
-const help = require('./help');
-const publishInit = require('./publish/index');
-const testInit = require('./test/index');
-const versionInfo = require('./version_info/index');
-const imageCut = require('./image_cut/index');
-const renameToEN = require('./rename_to_en');
-const npmPublish = require('./npm_publish');
-const iconPublish = require('./icon_publish');
-const log4js = require('log4js');
-
-const logger = log4js.getLogger('log2file');
-const exec = sh.exec;
-
-sh.exec = function (command, options) {
-    const temp = exec.apply(this, Array.prototype.slice.call(arguments));
-
-    if (!options || !options.silent) {
-        if (temp.stderr && temp.code !== 0) {
-            console.error(`【${command}】执行出错`);
-            logger.error(`${temp.stdout} ${temp.stderr.replace(/\n$/, '')}`);
-        } else {
-            logger.info(`【${command}】 ${temp.stdout.replace(/\n$/, '')}`);
-        }
-    }
-
-    return temp;
-};
+const sh = require('shelljs')
+const help = require('./help')
+const publishInit = require('./publish/index')
+const testInit = require('./test/index')
+const versionInfo = require('./version_info/index')
+const imageCut = require('./image_cut/index')
+const renameToEN = require('./rename_to_en')
+const npmPublish = require('./npm_publish')
+const iconPublish = require('./icon_publish')
+const logger = require('./logger')
 
 // help 信息
-const argv = help();
+const argv = help()
 
-logger.debug('gmfe argv:', argv);
+logger.debug('gmfe argv:', argv)
 
 // 参数校验
 if (argv._.length === 0) {
-    sh.exec('gmfe -h');
-    process.exit(0);
+  sh.exec('gmfe -h')
+  process.exit(0)
 }
 
 if (argv._.includes('publish') && argv.u) {
-    publishInit(argv.t, argv.u, argv.b);
+  publishInit(argv.t, argv.u, argv.b)
 } else if (argv._.includes('test')) {
-    testInit(argv.b);
+  testInit(argv.b)
 } else if (argv._.includes('versioninfo')) {
-    versionInfo(argv.w);
+  versionInfo(argv.w)
 } else if (argv._.includes('imagecut')) {
-    imageCut(argv.d, argv._[1]);
+  imageCut(argv.d, argv._[1])
 } else if (argv._.includes('renametoen')) {
-    renameToEN(argv._[1], argv._[2]);
+  renameToEN(argv._[1], argv._[2])
 } else if (argv._.includes('npm_publish')) {
-    npmPublish(argv.a);
-} else if(argv._.includes('icon_publish')) {
-    iconPublish(argv.d, argv.m);
-} else{
-    sh.exec('gmfe -h');
-    process.exit(0);
+  npmPublish(argv.a)
+} else if (argv._.includes('icon_publish')) {
+  iconPublish(argv.d, argv.m)
+} else {
+  sh.exec('gmfe -h')
+  process.exit(0)
 }

--- a/js/logger.js
+++ b/js/logger.js
@@ -29,7 +29,7 @@ let extra = {
   error (msg) {
     return base.error.call(logger, colors.red(msg))
   },
-  fatal (msg) {
+  fatalAndExit (msg) {
     logger.error(msg)
     process.exit(1)
   }

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,0 +1,39 @@
+const colors = require('colors')
+const log4js = require('log4js')
+
+const log4jsConfig = {
+  appenders: {
+    console: {
+      type: 'console',
+      layout: { type: 'coloured' }
+    }
+  },
+  categories: {
+    default: { appenders: ['console'], level: 'info' }
+  }
+}
+
+log4js.configure(log4jsConfig)
+let logger = log4js.getLogger('default')
+
+let base = Object.getPrototypeOf(logger)
+// info error只是为了加上一些颜色
+let extra = {
+  info (prefix, msg) {
+    if (msg == null) {
+      return base.info.call(logger, prefix)
+    }
+    prefix = colors.cyan(`「${prefix}」`)
+    return base.info.call(logger, `${prefix} ${msg}`)
+  },
+  error (msg) {
+    return base.error.call(logger, colors.red(msg))
+  },
+  fatal (msg) {
+    logger.error(msg)
+    process.exit(1)
+  }
+}
+console.log = logger.info.bind(logger)
+
+module.exports = Object.assign(logger, extra)

--- a/js/npm_publish/index.js
+++ b/js/npm_publish/index.js
@@ -1,58 +1,55 @@
-const sh = require('shelljs');
-const {logger, getProjectPath, getPackageJSON, getBranchName} = require('../util');
+const sh = require('../common/shelljs_wrapper')
+const { getProjectPath, getPackageJSON, getCurrentBranch } = require('../util')
+const { logger } = require('../logger')
 
-function _init(addWhat) {
-    // 前往工程的父目录
-    const projectPath = getProjectPath();
-    if (projectPath === false) {
-        logger.error('无法定位git工程');
-        return false;
+function _init (addWhat) {
+  // 前往工程的父目录
+  const projectPath = getProjectPath()
+  sh.cd(projectPath)
+
+  // 检测代码是否干净
+  const diff = sh.exec('git diff', { silent: true })
+  if (diff.stdout !== '') {
+    logger.warn('Dirty！确保你本地代码是干净的')
+    return false
+  }
+
+  // master
+  const currentBranch = getCurrentBranch()
+  if (currentBranch !== 'master') {
+    logger.warn('确保你处于master分支')
+    return false
+  }
+
+  const info = getPackageJSON()
+  if (!(info.repository && info.repository.url && info.repository.url.includes('https://github.com/gmfe/'))) {
+    logger.warn('确保是 github gmfe 的库')
+    return false
+  }
+
+  if (!sh.exec('npm whoami', { silent: true }).stdout.startsWith('gmfe')) {
+    logger.info('npm account is not gmfe')
+    return false
+  }
+
+  if (addWhat) {
+    if (addWhat === 'major' || addWhat === 'minor' || addWhat === 'patch') {
+      // 需要移除 package -lock.json 文件才能 npm version。
+      sh.exec(`rm -rf package-lock.json && npm version ${addWhat} && git push origin master:master;`)
+    } else {
+      logger.warn('-a 参数错误')
+      return false
     }
-    sh.cd(projectPath);
+  }
 
-    // 检测代码是否干净
-    const diff = sh.exec('git diff', {silent: true});
-    if (diff.stdout !== '') {
-        logger.warn('Dirty！确保你本地代码是干净的');
-        return false;
-    }
+  logger.info(`start to publish ${info.name} ...`)
+  sh.exec('npm publish --registry="https://registry.npmjs.org"; cnpm sync ' + info.name + ';')
 
-    // master
-    const currentBranch = getBranchName();
-    if (!currentBranch === 'master') {
-        logger.warn('确保你处于master分支');
-        return false;
-    }
-
-    const info = getPackageJSON();
-    if (!(info.repository && info.repository.url && info.repository.url.indexOf('https://github.com/gmfe/') > -1)) {
-        logger.warn('确保是 github gmfe 的库');
-        return false;
-    }
-
-    if (!sh.exec('npm whoami', {silent: true}).stdout.startsWith('gmfe')) {
-        logger.info('npm account is not gmfe');
-        return false;
-    }
-
-    if (addWhat) {
-        if (addWhat === 'major' || addWhat === 'minor' || addWhat === 'patch') {
-            // 需要移除 package-lock.json 文件才能 npm version。
-            sh.exec(`rm -rf package-lock.json; npm version ${addWhat}; git push origin master:master;`);
-        } else {
-            logger.warn('-a 参数错误');
-            return false;
-        }
-    }
-
-    logger.info(`start to publish ${info.name} ...`);
-    sh.exec('npm publish --registry="https://registry.npmjs.org"; cnpm sync ' + info.name + ';');
-
-    logger.info(`如果 cnpm 同步失败（最近经常同步失败），请访问 https://npm.taobao.org/sync/${info.name} 手动触发更新。`);
+  logger.info(`如果 cnpm 同步失败（最近经常同步失败），请访问 https://npm.taobao.org/sync/${info.name} 手动触发更新。`)
 }
 
 const init = (addWhat) => {
-    _init(addWhat) === false || process.exit(1);
-};
+  _init(addWhat) === false || process.exit(1)
+}
 
-module.exports = init;
+module.exports = init

--- a/js/publish/build.js
+++ b/js/publish/build.js
@@ -1,13 +1,14 @@
-const sh = require('shelljs');
-const { logger, getLastCommit } = require('../util');
+const sh = require('../common/shelljs_wrapper')
+const { getLastCommit } = require('../util')
+const logger = require('../logger')
 
-function build(branch = 'master') {
-    logger.info('>>>>>>>>>> 执行打包');
+function build (branch = 'master') {
+  logger.info('>>>>>>>>>> 执行打包')
 
-    logger.info('npm run deploy');
-    sh.exec(`BRANCH=${branch} COMMIT=${getLastCommit()} npm run deploy`);
+  logger.info('npm run deploy')
+  sh.exec(`BRANCH=${branch} COMMIT=${getLastCommit()} npm run deploy`)
 
-    logger.info('打包完成!');
+  logger.info('打包完成!')
 }
 
-module.exports = build;
+module.exports = build

--- a/js/publish/gray.js
+++ b/js/publish/gray.js
@@ -1,42 +1,28 @@
-const sh = require('shelljs');
-const fs = require('fs');
-const Util = require('../util');
-const { logger, getBranchName, getProjectName, getProjectPath } = Util;
+const sh = require('../common/shelljs_wrapper')
+const fs = require('fs')
+const Util = require('../util')
+const logger = require('../logger')
+const { getProjectName, getProjectPath } = Util
 
-function grayCheck(grayBranch) {
-    if (grayBranch.indexOf('release-') === -1) {
-        logger.warn(`分支${grayBranch}不正确，请输入以“release-“开头的的灰度分支名`);
-        process.exit(1);
-    }
+function grayCheck (grayBranch) {
+  if (!grayBranch.startsWith('release-')) {
+    logger.fatal(`分支${grayBranch}不正确，请输入以“release-“开头的的灰度分支名`)
+  }
 
-    const projectName = getProjectName(),
-        grayDir = `.gray_release/gm_static_${projectName}_${grayBranch}`;
+  const projectName = getProjectName()
+  const grayDir = `.gray_release/gm_static_${projectName}_${grayBranch}`
 
-    logger.info('>>>>>>>>>> 灰度发布准备');
+  logger.info('>>>>>>>>>> 灰度发布准备')
+  sh.exec('mkdir -p .gray_release', { silent: true })
 
-    sh.exec('mkdir -p .gray_release', { silent: true });
+  if (!fs.existsSync(grayDir)) {
+    sh.exec(`mkdir -p ${grayDir}`, { silent: true })
+    sh.exec(`rsync -aztHv  --exclude .test_release --exclude .gray_release --exclude backup . ${grayDir}`, { silent: true })
+  }
 
-    if (!fs.existsSync(grayDir)) {
-        sh.exec(`mkdir -p ${grayDir}`, { silent: true });
-        sh.exec(`rsync -aztHv  --exclude .test_release --exclude .gray_release --exclude backup . ${grayDir}`, { silent: true });
-    }
-
-    sh.cd(`${getProjectPath()}/${grayDir}`);
-
-    sh.exec('git pull');
-    sh.exec(`git checkout ${grayBranch}`, { silent: true });
-
-    const currentBranch = getBranchName();
-
-    if (currentBranch && currentBranch !== grayBranch) {
-        logger.warn(`分支${grayBranch}不存在，请输入准确的灰度分支名`);
-        process.exit(1);
-    }
-
-    logger.info('最近5次提交');
-    sh.exec('git log -n 5 --decorate=full');
-
-    logger.info('>>>>>>>>>> 灰度发布准备就绪');
+  sh.cd(`${getProjectPath()}/${grayDir}`)
+  sh.exec(`git checkout ${grayBranch}`, { silent: true })
+  sh.exec(`git pull origin ${grayBranch}`)
 }
 
-module.exports = grayCheck;
+module.exports = grayCheck

--- a/js/publish/index.js
+++ b/js/publish/index.js
@@ -1,58 +1,48 @@
-const sh = require("shelljs");
-const preview = require('./preview');
-const confirm = require('../common/confirm');
-const build = require('./build');
-const { online, postOnline } = require('./online');
-const rollback = require('./rollback');
-const gray = require('./gray');
-const { getBranchName, getProjectPath, logger } = require('../util');
+const sh = require('../common/shelljs_wrapper')
+const preview = require('./preview')
+const confirm = require('../common/confirm')
+const build = require('./build')
+const { online, postOnline } = require('./online')
+const rollback = require('./rollback')
+const grayCheck = require('./gray')
+const { getProjectPath } = require('../util')
+const logger = require('../logger')
 
-function init(tag, user, branch) {
-    // 前往工程的父目录
-    const projectPath = getProjectPath();
-    if (projectPath === false) {
-        logger.error('无法定位git工程');
-        process.exit(1);
-    }
-    sh.cd(projectPath);
+async function init (tag, user, branch = 'master') {
+  // 前往工程的父目录
+  const projectPath = getProjectPath()
+  sh.cd(projectPath)
 
-    // preview
-    // 主要是对当前的工程检查一遍
-    if (preview(branch) === false) {
-        process.exit(1);
-    }
+  // 主要是对当前的工程检查一遍
+  preview(branch)
 
-    // 灰度发布
-    if (branch) {
-        gray(branch);
-    }
+  // 灰度发布
+  if (branch !== 'master') {
+    grayCheck(branch)
+  }
 
-    // rollback
-    if (tag) {
-        confirm(`回滚到${tag}`).then(() => {
-            rollback(tag);
-            online(user);
-            postOnline(user);
-        }).catch(() => {
-            process.exit(1);
-        });
-    } else {
-        confirm(`打包${getBranchName()}分支`).then(() => {
-            build(branch);
+  logger.info('最近5次提交')
+  sh.exec('git log -n 5 --decorate=full')
+  logger.info(`>>>>>>>>>> ${branch}发布准备就绪`)
 
-            return confirm(branch ? '灰度上线' : '上线');
-        }).then(() => {
-            online(user);
-            postOnline(user, true);
-        }).catch(() => {
-            process.exit(1);
-        });
-    }
+  // rollback
+  if (tag) {
+    await confirm(`回滚到${tag}`)
+    rollback(tag)
+    online(user)
+    postOnline(user)
+  } else {
+    await confirm(`打包${branch}分支`)
+    build(branch)
 
-    // event
-    process.on('exit', function () {
-        logger.info('gmfe exit');
-    });
+    await confirm(branch !== 'master' ? '灰度上线' : '上线')
+    online(user)
+    postOnline(user, true)
+  }
+
+  process.on('exit', function () {
+    logger.info('gmfe exit')
+  })
 }
 
-module.exports = init;
+module.exports = init

--- a/js/publish/index.js
+++ b/js/publish/index.js
@@ -4,7 +4,7 @@ const confirm = require('../common/confirm')
 const build = require('./build')
 const { online, postOnline } = require('./online')
 const rollback = require('./rollback')
-const grayCheck = require('./gray')
+const prepareGray = require('./prepare_gray')
 const { getProjectPath } = require('../util')
 const logger = require('../logger')
 
@@ -13,32 +13,32 @@ async function init (tag, user, branch = 'master') {
   const projectPath = getProjectPath()
   sh.cd(projectPath)
 
+  // 回滚master或灰度分支
+  // 去对应目录解压backup中的备份
+  if (tag) {
+    await rollback(tag, branch)
+    online(user)
+    postOnline(user)
+    return
+  }
+
   // 主要是对当前的工程检查一遍
   preview(branch)
 
-  // 灰度发布
+  // 灰度准备
   if (branch !== 'master') {
-    grayCheck(branch)
+    prepareGray(branch)
   }
 
   logger.info('最近5次提交')
   sh.exec('git log -n 5 --decorate=full')
   logger.info(`>>>>>>>>>> ${branch}发布准备就绪`)
 
-  // rollback
-  if (tag) {
-    await confirm(`回滚到${tag}`)
-    rollback(tag)
-    online(user)
-    postOnline(user)
-  } else {
-    await confirm(`打包${branch}分支`)
-    build(branch)
-
-    await confirm(branch !== 'master' ? '灰度上线' : '上线')
-    online(user)
-    postOnline(user, true)
-  }
+  await confirm(`打包${branch}分支`)
+  build(branch)
+  await confirm(branch !== 'master' ? '灰度上线' : '上线')
+  online(user)
+  postOnline(user, true)
 
   process.on('exit', function () {
     logger.info('gmfe exit')

--- a/js/publish/prepare_gray.js
+++ b/js/publish/prepare_gray.js
@@ -2,15 +2,15 @@ const sh = require('../common/shelljs_wrapper')
 const fs = require('fs')
 const Util = require('../util')
 const logger = require('../logger')
-const { getProjectName, getProjectPath } = Util
+const { getProjectName, getProjectPath, getGrayDir } = Util
 
-function grayCheck (grayBranch) {
+function prepareGray (grayBranch) {
   if (!grayBranch.startsWith('release-')) {
-    logger.fatal(`分支${grayBranch}不正确，请输入以“release-“开头的的灰度分支名`)
+    logger.fatalAndExit(`分支${grayBranch}不正确，请输入以“release-“开头的的灰度分支名`)
   }
 
   const projectName = getProjectName()
-  const grayDir = `.gray_release/gm_static_${projectName}_${grayBranch}`
+  const grayDir = getGrayDir(projectName, grayBranch)
 
   logger.info('>>>>>>>>>> 灰度发布准备')
   sh.exec('mkdir -p .gray_release', { silent: true })
@@ -25,4 +25,4 @@ function grayCheck (grayBranch) {
   sh.exec(`git pull origin ${grayBranch}`)
 }
 
-module.exports = grayCheck
+module.exports = prepareGray

--- a/js/publish/preview.js
+++ b/js/publish/preview.js
@@ -1,40 +1,15 @@
-const sh = require('shelljs');
-const Util = require('../util');
-const { logger, getBranchName } = Util;
+const sh = require('../common/shelljs_wrapper')
+const commonPreview = require('../common/preview')
+const logger = require('../logger')
+const GATE_PROJECT_PATH = '/data/gmfe_static'
 
-function preview(grayBranch) {
-    const currentBranch = getBranchName();
+function preview (branch) {
+  logger.info('>>>>>>>>>> 发布前检测')
 
-    logger.info('>>>>>>>>>> 发布前检测');
-
-    logger.info('检测本地代码状态');
-    const diff = sh.exec('git diff', { silent: true });
-    if (diff.stdout !== '') {
-        logger.warn('Dirty！确保你本地代码是干净的');
-        return false;
-    }
-
-    if (!currentBranch) {
-        logger.warn('确保你处于master、online分支');
-        return false;
-    }
-
-    logger.info('拉远端代码');
-    sh.exec('git pull');
-
-    logger.info('比较远端代码');
-    const oDiff = sh.exec(`git diff ${currentBranch} origin/${currentBranch}`, { silent: true });
-    if (oDiff.stdout !== '') {
-        logger.warn(`${currentBranch}不同于origin/${currentBranch}。请检查！`);
-        return false;
-    }
-
-    if (!grayBranch) {
-        logger.info('最近5次提交');
-        sh.exec('git log -n 5 --decorate=full');
-    }
-
-    return true;
+  if (!sh.pwd().startsWith(GATE_PROJECT_PATH)) {
+    logger.fatal(`确保处于gate机器 ${GATE_PROJECT_PATH}`)
+  }
+  commonPreview(branch)
 }
 
-module.exports = preview;
+module.exports = preview

--- a/js/publish/preview.js
+++ b/js/publish/preview.js
@@ -7,7 +7,7 @@ function preview (branch) {
   logger.info('>>>>>>>>>> 发布前检测')
 
   if (!sh.pwd().startsWith(GATE_PROJECT_PATH)) {
-    logger.fatal(`确保处于gate机器 ${GATE_PROJECT_PATH}`)
+    logger.fatalAndExit(`确保处于gate机器 ${GATE_PROJECT_PATH}`)
   }
   commonPreview(branch)
 }

--- a/js/publish/rollback.js
+++ b/js/publish/rollback.js
@@ -1,18 +1,22 @@
 const sh = require('../common/shelljs_wrapper')
 const fs = require('fs')
+const path = require('path')
 const logger = require('../logger')
+const confirm = require('../common/confirm')
+const { getGrayDir, getProjectName } = require('../util')
 
-function rollback (tag) {
+async function rollback (tag, branch) {
+  if (branch !== 'master') {
+    sh.cd(getGrayDir(getProjectName(), branch))
+  }
   const fileName = `backup/${tag}.tar.gz`
-
-  const isExist = fs.existsSync(fileName)
-
-  logger.info('>>>>>>>>>> 执行rollback')
-
-  if (!isExist) {
-    logger.fatal(`${fileName}不存在`)
+  if (!fs.existsSync(fileName)) {
+    logger.fatalAndExit(`${path.resolve(fileName)}不存在`)
   }
 
+  await confirm(`回滚${branch}到${tag}`)
+
+  logger.info('>>>>>>>>>> 执行rollback')
   logger.info(`解压 ${fileName}`)
   sh.exec(`tar zxvf ${fileName} -C ./`)
   logger.info(`解压完成`)

--- a/js/publish/rollback.js
+++ b/js/publish/rollback.js
@@ -1,22 +1,21 @@
-const sh = require('shelljs');
-const fs = require('fs');
-const Util = require('../util');
-const { logger } = Util;
+const sh = require('../common/shelljs_wrapper')
+const fs = require('fs')
+const logger = require('../logger')
 
-function rollback(tag) {
-    const fileName = `backup/${tag}.tar.gz`,
-        isExist = fs.existsSync(fileName);
+function rollback (tag) {
+  const fileName = `backup/${tag}.tar.gz`
 
-    logger.info('>>>>>>>>>> 执行rollback');
+  const isExist = fs.existsSync(fileName)
 
-    if (!isExist) {
-        logger.error(`${fileName}不存在`);
-        process.exit(1);
-    }
+  logger.info('>>>>>>>>>> 执行rollback')
 
-    logger.info(`解压 ${fileName}`);
-    sh.exec(`tar zxvf ${fileName} -C ./`);
-    logger.info(`解压完成`);
+  if (!isExist) {
+    logger.fatal(`${fileName}不存在`)
+  }
+
+  logger.info(`解压 ${fileName}`)
+  sh.exec(`tar zxvf ${fileName} -C ./`)
+  logger.info(`解压完成`)
 }
 
-module.exports = rollback;
+module.exports = rollback

--- a/js/rename_to_en/index.js
+++ b/js/rename_to_en/index.js
@@ -1,62 +1,62 @@
-const fs = require('fs');
-const path = require('path');
-const sh = require('shelljs');
-const {logger} = require('../util');
-const pinyin = require('gm-pinyin');
-const _ = require('lodash');
+const fs = require('fs')
+const path = require('path')
+const sh = require('../common/shelljs_wrapper')
+const logger = require('../logger')
+const pinyin = require('gm-pinyin')
+const _ = require('lodash')
 
-function batchRenameDirToEN(dir = './images', dist = './rename') {
-    const dirPath = path.resolve(dir);
-    const distPath = path.resolve(dist);
+function batchRenameDirToEN (dir = './images', dist = './rename') {
+  const dirPath = path.resolve(dir)
+  const distPath = path.resolve(dist)
 
-    if (!fs.existsSync(dirPath)) {
-        logger.error('无法定位文件');
-        process.exit(1);
-    }
+  if (!fs.existsSync(dirPath)) {
+    logger.error('无法定位文件')
+    process.exit(1)
+  }
 
-    if (fs.existsSync(distPath)) {
-        sh.exec('rm -rf ' + distPath);
-    }
+  if (fs.existsSync(distPath)) {
+    sh.exec('rm -rf ' + distPath)
+  }
 
-    sh.exec('mkdir ' + distPath);
+  sh.exec('mkdir ' + distPath)
 
-    const files = fs.readdirSync(dirPath);
+  const files = fs.readdirSync(dirPath)
 
-    _.each(files, filename => {
-        fs.copyFileSync(path.join(dirPath, filename), path.join(distPath, getPinyinStr(filename)));
-    });
+  _.each(files, filename => {
+    fs.copyFileSync(path.join(dirPath, filename), path.join(distPath, getPinyinStr(filename)))
+  })
 }
 
-function batchPinyin(dir = './name.txt', dist = './rename.txt') {
-    const dirPath = path.resolve(dir);
-    const distPath = path.resolve(dist);
+function batchPinyin (dir = './name.txt', dist = './rename.txt') {
+  const dirPath = path.resolve(dir)
+  const distPath = path.resolve(dist)
 
-    if (!fs.existsSync(dirPath)) {
-        logger.error('无法定位文件');
-        process.exit(1);
-    }
+  if (!fs.existsSync(dirPath)) {
+    logger.error('无法定位文件')
+    process.exit(1)
+  }
 
-    const text = fs.readFileSync(dirPath, 'utf-8');
-    const arr = [];
-    text.split('/\r?\n/').forEach(line => {
-        arr.push(getPinyinStr(line));
-    });
+  const text = fs.readFileSync(dirPath, 'utf-8')
+  const arr = []
+  text.split('/\r?\n/').forEach(line => {
+    arr.push(getPinyinStr(line))
+  })
 
-    fs.writeFile(distPath, getPinyinStr(text), 'utf-8');
+  fs.writeFile(distPath, getPinyinStr(text), 'utf-8')
 }
 
-function batchRenameToEN(dir, dist) {
-    if (dir.includes('.')) {
-        batchPinyin(dir, dist);
-    } else {
-        batchRenameDirToEN(dir, dist);
-    }
+function batchRenameToEN (dir, dist) {
+  if (dir.includes('.')) {
+    batchPinyin(dir, dist)
+  } else {
+    batchRenameDirToEN(dir, dist)
+  }
 }
 
-function getPinyinStr(text) {
-    return _.map(pinyin(text, {
-        style: pinyin.STYLE_NORMAL
-    }), v => v[0]).join('');
+function getPinyinStr (text) {
+  return _.map(pinyin(text, {
+    style: pinyin.STYLE_NORMAL
+  }), v => v[0]).join('')
 }
 
-module.exports = batchRenameToEN;
+module.exports = batchRenameToEN

--- a/js/test/index.js
+++ b/js/test/index.js
@@ -1,56 +1,56 @@
-const sh = require("shelljs");
-const preview = require('./preview');
-const testCheck = require('./test_check');
-const { getProjectPath, getProjectName, logger, getLastCommit } = require('../util');
+const sh = require('../common/shelljs_wrapper')
+const preview = require('./preview')
+const testCheck = require('./test_check')
+const { getProjectPath, getProjectName, getLastCommit } = require('../util')
+const logger = require('../logger')
 
-function init(branch = "master") {
-    // 前往工程的父目录
-    const projectPath = getProjectPath();
-    if (projectPath === false) {
-        logger.error('无法定位git工程');
-        process.exit(1);
-    }
-    sh.cd(projectPath);
+function init (branch = 'master') {
+  // 前往工程的父目录
+  const projectPath = getProjectPath()
+  sh.cd(projectPath)
 
-    // preview
-    // 主要是对当前的工程检查一遍
-    if (preview() === false) {
-        process.exit(1);
-    }
+  // 主要是对当前的工程检查一遍
+  preview(branch)
 
-    // 灰度发布
-    if (branch !== 'master')
-        testCheck(branch);
+  logger.info('>>>>>>>>>> 测试部署准备')
+  // 测试发布 进入.test_release 拉最新代码
+  if (branch !== 'master') {
+    testCheck(branch)
+  }
 
-    logger.info('>>>>>>>>>> 执行打包');
+  logger.info('最近5次提交')
+  sh.exec('git log -n 5 --decorate=full')
+  logger.info('>>>>>>>>>> 测试部署准备就绪')
 
-    sh.exec(`BRANCH=${branch} COMMIT=${getLastCommit()} npm run testing`);
+  logger.info('>>>>>>>>>> 执行打包')
 
-    logger.info('打包完成!');
+  sh.exec(`BRANCH=${branch} COMMIT=${getLastCommit()} npm run testing`)
 
-    const projectName = getProjectName(),
-        distPath = `/data/templates/${projectName}/${branch}/`;
+  logger.info('打包完成!')
 
-    sh.exec(`rsync -aztHv ./build/ /data/www/static_resource/${projectName}/`);
+  const projectName = getProjectName()
+  const distPath = `/data/templates/${projectName}/${branch}/`
 
-    // 确保distPath目录存在
-    sh.exec(`mkdir -p ${distPath};`);
-    sh.exec(`ssh devhost.guanmai.cn mkdir -p ${distPath};`);
+  sh.exec(`rsync -aztHv ./build/ /data/www/static_resource/${projectName}/`)
 
-    if (projectName === 'mes') {
-        sh.exec(`rsync -aztHv ./build/mes.html dev.guanmai.cn:${distPath}`);
-        sh.exec(`rsync -aztHv ./build/mes.html devhost.guanmai.cn:${distPath}`);
-    } else {
-        sh.exec(`rsync -aztHv ./build/index.html dev.guanmai.cn:${distPath}`);
-        sh.exec(`rsync -aztHv ./build/index.html devhost.guanmai.cn:${distPath}`);
-    }
+  // 确保distPath目录存在
+  sh.exec(`mkdir -p ${distPath};`)
+  sh.exec(`ssh devhost.guanmai.cn mkdir -p ${distPath};`)
 
-    logger.info('测试部署完成!');
+  if (projectName === 'mes') {
+    sh.exec(`rsync -aztHv ./build/mes.html dev.guanmai.cn:${distPath}`)
+    sh.exec(`rsync -aztHv ./build/mes.html devhost.guanmai.cn:${distPath}`)
+  } else {
+    sh.exec(`rsync -aztHv ./build/index.html dev.guanmai.cn:${distPath}`)
+    sh.exec(`rsync -aztHv ./build/index.html devhost.guanmai.cn:${distPath}`)
+  }
 
-    // event
-    process.on('exit', function () {
-        logger.info('gmfe exit');
-    });
+  logger.info('测试部署完成!')
+
+  // event
+  process.on('exit', function () {
+    logger.info('gmfe exit')
+  })
 }
 
-module.exports = init;
+module.exports = init

--- a/js/test/index.js
+++ b/js/test/index.js
@@ -1,6 +1,6 @@
 const sh = require('../common/shelljs_wrapper')
 const preview = require('./preview')
-const testCheck = require('./test_check')
+const prepareTest = require('./prepare_test')
 const { getProjectPath, getProjectName, getLastCommit } = require('../util')
 const logger = require('../logger')
 
@@ -15,7 +15,7 @@ function init (branch = 'master') {
   logger.info('>>>>>>>>>> 测试部署准备')
   // 测试发布 进入.test_release 拉最新代码
   if (branch !== 'master') {
-    testCheck(branch)
+    prepareTest(branch)
   }
 
   logger.info('最近5次提交')

--- a/js/test/prepare_test.js
+++ b/js/test/prepare_test.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const Util = require('../util')
 const { getProjectName, getProjectPath } = Util
 
-function testCheck (testBranch) {
+function prepareTest (testBranch) {
   const projectName = getProjectName()
 
   const testDir = `.test_release/gm_static_${projectName}_${testBranch}`
@@ -20,4 +20,4 @@ function testCheck (testBranch) {
   sh.exec(`git pull origin ${testBranch}`)
 }
 
-module.exports = testCheck
+module.exports = prepareTest

--- a/js/test/preview.js
+++ b/js/test/preview.js
@@ -1,35 +1,15 @@
-const sh = require('shelljs');
-const Util = require('../util');
-const { logger } = Util;
+const sh = require('../common/shelljs_wrapper')
+const commonPreview = require('../common/preview')
+const logger = require('../logger')
+const DEV_PROJECT_PATH = '/data/www/'
 
-function preview() {
-    let branch = sh.exec("git branch | sed -n '/\\* /s///p'", { silent: true }).stdout.replace('\n', '');
-
-    logger.info('>>>>>>>>>> 测试部署前检测');
-
-    logger.info('检测本地代码状态');
-    const diff = sh.exec('git diff', { silent: true });
-    if (diff.stdout !== '') {
-        logger.warn('Dirty！确保你本地代码是干净的');
-        return false;
-    }
-
-    if (branch !== 'master') {
-        sh.exec('git checkout master');
-        branch = 'master';
-    }
-
-    logger.info('拉远端代码');
-    sh.exec('git pull');
-
-    logger.info('比较远端代码');
-    const oDiff = sh.exec(`git diff ${branch} origin/${branch}`, { silent: true });
-    if (oDiff.stdout !== '') {
-        logger.warn(`${branch}不同于origin/${branch}。请检查！`);
-        return false;
-    }
-
-    return true;
+function preview (testBranch) {
+  logger.info('>>>>>>>>>> 测试部署前检测')
+  // 检测dev机
+  if (!sh.pwd().startsWith(DEV_PROJECT_PATH)) {
+    logger.fatal(`确保处于test机器 ${DEV_PROJECT_PATH}`)
+  }
+  commonPreview(testBranch)
 }
 
-module.exports = preview;
+module.exports = preview

--- a/js/test/test_check.js
+++ b/js/test/test_check.js
@@ -1,37 +1,23 @@
-const sh = require('shelljs');
-const fs = require('fs');
-const Util = require('../util');
-const { logger, getProjectName, getProjectPath } = Util;
+const sh = require('../common/shelljs_wrapper')
+const fs = require('fs')
+const Util = require('../util')
+const { getProjectName, getProjectPath } = Util
 
-function testCheck(testBranch) {
-    const projectName = getProjectName(),
-        testDir = `.test_release/gm_static_${projectName}_${testBranch}`;
+function testCheck (testBranch) {
+  const projectName = getProjectName()
 
-    logger.info('>>>>>>>>>> 测试部署准备');
+  const testDir = `.test_release/gm_static_${projectName}_${testBranch}`
 
-    sh.exec('mkdir -p .test_release', { silent: true });
+  sh.exec('mkdir -p .test_release', { silent: true })
 
-    if (!fs.existsSync(testDir)) {
-        sh.exec(`mkdir -p ${testDir}`, { silent: true });
-        sh.exec(`rsync -aztHv --exclude .test_release --exclude .gray_release --exclude backup . ${testDir}`, { silent: true });
-    }
+  if (!fs.existsSync(testDir)) {
+    sh.exec(`mkdir -p ${testDir}`, { silent: true })
+    sh.exec(`rsync -aztHv --exclude .test_release --exclude .gray_release --exclude backup . ${testDir}`, { silent: true })
+  }
 
-    sh.cd(`${getProjectPath()}/${testDir}`);
-
-    sh.exec(`git checkout ${testBranch}`, { silent: true });
-    sh.exec(`git pull origin ${testBranch}`);
-
-    const currentBranch = sh.exec("git branch | sed -n '/\\* /s///p'", { silent: true }).stdout.replace('\n', '');
-
-    if (currentBranch !== testBranch) {
-        logger.warn(`分支${testBranch}不存在，请输入准确的分支名`);
-        process.exit(1);
-    }
-
-    logger.info('最近5次提交');
-    sh.exec('git log -n 5 --decorate=full');
-
-    logger.info('>>>>>>>>>> 测试部署准备就绪');
+  sh.cd(`${getProjectPath()}/${testDir}`)
+  sh.exec(`git checkout ${testBranch}`, { silent: true })
+  sh.exec(`git pull origin ${testBranch}`)
 }
 
-module.exports = testCheck;
+module.exports = testCheck

--- a/js/util.js
+++ b/js/util.js
@@ -9,7 +9,7 @@ function getProjectPath () {
     }
     return dir.stdout.replace(/\/.git|\n/g, '')
   } catch (e) {
-    logger.fatal('无法定位git工程')
+    logger.fatalAndExit('无法定位git工程')
   }
 }
 
@@ -22,7 +22,7 @@ const verifyBranch = (branch) => {
   try {
     sh.exec(`git rev-parse --verify origin/${branch}`, { silent: true })
   } catch (e) {
-    logger.fatal(`分支${branch}不存在，请输入准确的分支名`)
+    logger.fatalAndExit(`分支${branch}不存在，请输入准确的分支名`)
   }
 }
 
@@ -46,6 +46,10 @@ const getPackageJSON = () => {
   return JSON.parse(sh.exec('cat package.json', { silent: true }).stdout)
 }
 
+const getGrayDir = (projectName, grayBranch) => {
+  return `.gray_release/gm_static_${projectName}_${grayBranch}`
+}
+
 module.exports = {
   verifyBranch,
   getCurrentBranch,
@@ -53,5 +57,6 @@ module.exports = {
   getProjectName,
   remoteTemplatePathCheck,
   getPackageJSON,
-  getLastCommit
+  getLastCommit,
+  getGrayDir
 }

--- a/js/util.js
+++ b/js/util.js
@@ -1,97 +1,57 @@
-const sh = require('shelljs');
-var fs = require('fs');
-const log4js = require('log4js');
+const sh = require('./common/shelljs_wrapper')
+const logger = require('./logger')
 
-const log4jsConfig = {
-    appenders: {
-        console: {
-            type: 'console',
-            layout: { type: 'coloured' }
-        }
-    },
-    categories: {
-        default: { appenders: ['console'], level: 'debug' },
-        log2file: { appenders: ['console'], level: 'debug' }
+function getProjectPath () {
+  try {
+    const dir = sh.exec('git rev-parse --git-dir', { silent: true })
+    if (dir.stdout === '.git\n') {
+      return sh.pwd()
     }
-};
-
-const projectPath = getProjectPath();
-
-// 只在工程目录下时才记录到日志文件
-if (projectPath) {
-    const logDirectory = `${projectPath}/logs`;
-
-    if (!fs.existsSync(logDirectory)) {
-        fs.mkdirSync(logDirectory);
-    }
-
-    log4jsConfig.appenders.log2file = {
-        type: 'fileSync', filename: `${logDirectory}/gmfe.log`, maxLogSize: 10458760, pattern: '.yyyy-MM', compress: true,
-        layout: { type: 'coloured' }
-    };
-
-    log4jsConfig.categories = {
-        default: { appenders: ['log2file', 'console'], level: 'debug' },
-        log2file: { appenders: ['log2file'], level: 'debug' }
-    };
+    return dir.stdout.replace(/\/.git|\n/g, '')
+  } catch (e) {
+    logger.fatal('无法定位git工程')
+  }
 }
 
-log4js.configure(log4jsConfig);
-
-const logger = log4js.getLogger('default');
-console.log = logger.info.bind(logger);
-console.error = logger.error.bind(logger);
-
-
-function getProjectPath() {
-    const dir = sh.exec('git rev-parse --git-dir', { silent: true });
-    if (dir.code === 0) {
-        if (dir.stdout === '.git\n') {
-            return sh.pwd();
-        } else {
-            return dir.stdout.replace('/.git', '').replace('\n', '');
-        }
-    } else {
-        return false;
-    }
+const getCurrentBranch = () => {
+  const branch = sh.exec("git branch | sed -n '/\\* /s///p'", { silent: true }).stdout.replace('\n', '')
+  return branch
 }
 
-// TODO 貌似语义不符
-const getBranchName = () => {
-    const branch = sh.exec('git branch', { silent: true }),
-        branchNameMatch = branch.stdout.match(/\*\s+(master)\n/) || branch.stdout.match(/\*\s+(online-.+)\n/) || branch.stdout.match(/\*\s+(release-.+)\n/);
-
-    return branchNameMatch && branchNameMatch[1];
-};
+const verifyBranch = (branch) => {
+  try {
+    sh.exec(`git rev-parse --verify origin/${branch}`, { silent: true })
+  } catch (e) {
+    logger.fatal(`分支${branch}不存在，请输入准确的分支名`)
+  }
+}
 
 const getLastCommit = () => {
-    return sh.exec('git rev-parse --short HEAD', { silent: true }).stdout.replace('\n', '');
-};
+  return sh.exec('git rev-parse --short HEAD', { silent: true }).stdout.replace('\n', '')
+}
 
 const getProjectName = () => {
-    const projectPath = getProjectPath();
+  const projectPath = getProjectPath()
 
-    if (!projectPath) return null;
-
-    return projectPath.split('/').pop().split('_')[2];
-};
+  return projectPath.split('/').pop().split('_')[2]
+}
 
 const remoteTemplatePathCheck = (branch) => {
-    const check = sh.exec(`if ssh static.cluster.gm '[ -d /data/templates/${getProjectName()}/${branch || getBranchName()}/ ]'; then echo "succ"; exit 1; else echo "fail"; fi`, { silent: true });
+  const check = sh.exec(`if ssh static.cluster.gm '[ -d /data/templates/${getProjectName()}/${branch || getCurrentBranch()}/ ]'; then echo "succ"; exit 1; else echo "fail"; fi`, { silent: true })
 
-    return check.stdout === 'succ\n';
-};
+  return check.stdout === 'succ\n'
+}
 
 const getPackageJSON = () => {
-    return JSON.parse(sh.exec('cat package.json', { silent: true }).stdout);
-};
+  return JSON.parse(sh.exec('cat package.json', { silent: true }).stdout)
+}
 
 module.exports = {
-    logger,
-    getProjectPath,
-    getBranchName,
-    getProjectName,
-    remoteTemplatePathCheck,
-    getPackageJSON,
-    getLastCommit
-};
+  verifyBranch,
+  getCurrentBranch,
+  getProjectPath,
+  getProjectName,
+  remoteTemplatePathCheck,
+  getPackageJSON,
+  getLastCommit
+}

--- a/js/version_info/index.js
+++ b/js/version_info/index.js
@@ -1,90 +1,90 @@
-const sh = require('shelljs');
-const _ = require('lodash');
-const moment = require('moment');
-const { logger } = require('../util');
-const fs = require('fs');
-const colors = require('colors');
+const sh = require('../common/shelljs_wrapper')
+const _ = require('lodash')
+const moment = require('moment')
+const logger = require('../logger')
+const fs = require('fs')
+const colors = require('colors')
 
 const configProject = [
-    { name: 'gm_static_station', desc: 'Station' },
-    { name: 'gm_static_manage', desc: 'MA' },
-    { name: 'gm_static_bshop', desc: 'BShop' },
-    { name: 'gm_static_dealer', desc: '配送商导航' },
-    { name: 'gm_static_admin', desc: 'Admin' },
-    { name: 'gm_official', desc: '官网' }
+  { name: 'gm_static_station', desc: 'Station' },
+  { name: 'gm_static_manage', desc: 'MA' },
+  { name: 'gm_static_bshop', desc: 'BShop' },
+  { name: 'gm_static_dealer', desc: '配送商导航' },
+  { name: 'gm_static_admin', desc: 'Admin' },
+  { name: 'gm_official', desc: '官网' }
 
-    // {name: 'gmrnbshop', desc: 'BShop APP'},
-    // {name: 'gmrnmes', desc: 'pad 称重打印'},
-    // {name: 'gmrnpa', desc: '采购工具'},
-];
+  // {name: 'gmrnbshop', desc: 'BShop APP'},
+  // {name: 'gmrnmes', desc: 'pad 称重打印'},
+  // {name: 'gmrnpa', desc: '采购工具'},
+]
 
-function showVersionInfo(project, desc, w = 1) {
-    sh.cd(project);
+function showVersionInfo (project, desc, w = 1) {
+  sh.cd(project)
 
-    const stdout = sh.exec(`git log --merges -n ${w * 20} --decorate=full --pretty="format:>>>>>>>>>>%n-->>hash: %h%n-->>author: %an%n-->>date: %aI%n-->>subject: %s%n-->>body: %b"`, { silent: true }).stdout;
+  const stdout = sh.exec(`git log --merges -n ${w * 20} --decorate=full --pretty="format:>>>>>>>>>>%n-->>hash: %h%n-->>author: %an%n-->>date: %aI%n-->>subject: %s%n-->>body: %b"`, { silent: true }).stdout
 
-    let result = [];
-    _.each(stdout.split('>>>>>>>>>>').slice(1), str => {
-        const arr = str.split('-->>').slice(1);
+  let result = []
+  _.each(stdout.split('>>>>>>>>>>').slice(1), str => {
+    const arr = str.split('-->>').slice(1)
 
-        result.push({
-            hash: arr[0].slice(6, -1),
-            author: arr[1].slice(8, -1),
-            date: arr[2].slice(6, -1),
-            subject: arr[3].slice(9, -1),
-            body: arr[4].slice(6, -1)
-        });
-    });
+    result.push({
+      hash: arr[0].slice(6, -1),
+      author: arr[1].slice(8, -1),
+      date: arr[2].slice(6, -1),
+      subject: arr[3].slice(9, -1),
+      body: arr[4].slice(6, -1)
+    })
+  })
 
-    const minDate = moment().add(-w + 1, 'w').startOf('week');
+  const minDate = moment().add(-w + 1, 'w').startOf('week')
 
-    result = _.filter(result, info => moment(info.date) >= minDate);
+  result = _.filter(result, info => moment(info.date) >= minDate)
 
-    console.log(colors.green(`${desc} ${w} 周内（${moment().format('YYYY-MM-DD')}~${minDate.format('YYYY-MM-DD')}）${result.length} 次发布`));
+  console.log(colors.green(`${desc} ${w} 周内（${moment().format('YYYY-MM-DD')}~${minDate.format('YYYY-MM-DD')}）${result.length} 次发布`))
 
-    _.each(result, info => {
-        console.log(colors.cyan('>>>>>>>>>>'));
-        console.log(`hash: ${info.hash}
+  _.each(result, info => {
+    console.log(colors.cyan('>>>>>>>>>>'))
+    console.log(`hash: ${info.hash}
 author: ${info.author}
 date: ${info.date}˚
 subject: ${info.subject}
 body: ${info.body}
-`);
-    });
+`)
+  })
 }
 
-function init(week) {
-    const root = '~/.gmfe_version_info';
+function init (week) {
+  const root = '~/.gmfe_version_info'
 
-    logger.info('********************');
-    logger.info('列出工程最近发布记录');
+  logger.info('********************')
+  logger.info('列出工程最近发布记录')
 
-    const isPathExist = fs.existsSync(root);
+  const isPathExist = fs.existsSync(root)
 
-    if (!isPathExist) {
-        sh.exec('mkdir -p ' + root);
+  if (!isPathExist) {
+    sh.exec('mkdir -p ' + root)
+  }
+
+  sh.cd(root)
+
+  _.each(configProject, p => {
+    sh.cd(root)
+    if (!fs.existsSync(p.name)) {
+      sh.exec('mkdir -p ' + p.name)
+      sh.exec(`git clone git@code.guanmai.cn:front-end/${p.name}.git`)
     }
+    sh.cd(p.name)
+    sh.exec('git checkout master; git pull;')
+  })
 
-    sh.cd(root);
-
-    _.each(configProject, p => {
-        sh.cd(root);
-        if (!fs.existsSync(p.name)) {
-            sh.exec('mkdir -p ' + p.name);
-            sh.exec(`git clone git@code.guanmai.cn:front-end/${p.name}.git`);
-        }
-        sh.cd(p.name);
-        sh.exec('git checkout master; git pull;');
-    });
-
-    _.each(configProject, p => {
-        sh.cd(root);
-        sh.pwd();
-        console.log('');
-        console.log('');
-        console.log('');
-        showVersionInfo(p.name, p.desc, week);
-    });
+  _.each(configProject, p => {
+    sh.cd(root)
+    sh.pwd()
+    console.log('')
+    console.log('')
+    console.log('')
+    showVersionInfo(p.name, p.desc, week)
+  })
 }
 
-module.exports = init;
+module.exports = init

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "colors": "^1.2.5",
     "gm-jsonconf": "^2.0.0",
     "gm-pinyin": "^3.0.0",
+    "inquirer": "^6.0.0",
     "lodash": "^4.17.10",
     "log4js": "^2.6.1",
     "moment": "^2.22.1",
@@ -32,5 +33,16 @@
     "shelljs": "^0.8.2",
     "ssh2": "^0.6.1",
     "yargs": "^8.0.2"
+  },
+  "devDependencies": {
+    "babel-eslint": "^8.2.6",
+    "eslint": "^5.2.0",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-config-standard-jsx": "^5.0.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-react": "^7.10.0",
+    "eslint-plugin-standard": "^3.1.0"
   }
 }


### PR DESCRIPTION
1. 删除写入到`gmfe.log`的`logger`
2. 包装`shelljs`，执行命令时打印`log`，如果出错则终止
3. `preview`增加路径判断，`test`和`publish`的`preview`逻辑基本保持一致
4. 精简`confirm`为`inquirer`实现
5. `standard`
6. 整理部分代码逻辑(主要是`test`和`publish`)

close #17  