### PR TITLE
feat: 配合后端新发布脚本修改

### DIFF
--- a/js/common/confirm.js
+++ b/js/common/confirm.js
@@ -1,10 +1,10 @@
 const inquirer = require('inquirer')
 
-async function confirm (action) {
+async function confirm (action, exitIfNo = true) {
   let result = await inquirer.prompt({
     type: 'input',
     name: action,
-    message: `确认是否 ${action} (yes/no)`,
+    message: `确认: ${action} (yes/no)`,
     validate (input) {
       if (input !== 'yes' && input !== 'no') {
         return 'please input yes or no'
@@ -12,9 +12,11 @@ async function confirm (action) {
       return true
     }
   })
-  if (result[action] === 'no') {
+  let yes = result[action] === 'yes'
+  if (!yes && exitIfNo) {
     process.exit(0)
   }
+  return yes
 }
 
 module.exports = confirm

--- a/js/common/shelljs_wrapper.js
+++ b/js/common/shelljs_wrapper.js
@@ -18,14 +18,12 @@ let extra = {
     if (execResult.code !== 0) {
       const msg = execResult.stderr
       logger.error(`【${command}】执行出错 \n${msg}`)
-      throw new Error('')
+      if (!options.ignoreError) {
+        throw new Error('')
+      }
     }
     return execResult
   }
 }
 
-module.exports = Object.assign(
-  {},
-  sh,
-  extra
-)
+module.exports = Object.assign({}, sh, extra)

--- a/js/icon_publish/index.js
+++ b/js/icon_publish/index.js
@@ -9,11 +9,11 @@ const _init = (filePath, commit = '新增icon') => {
 
   const packageJSON = getPackageJSON()
   if (packageJSON.name !== 'gm-xfont') {
-    logger.fatal('当前工程不是gm-xfont')
+    logger.fatalAndExit('当前工程不是gm-xfont')
   }
 
   if (!fs.existsSync(filePath)) {
-    logger.fatal('请确认icon压缩包路径')
+    logger.fatalAndExit('请确认icon压缩包路径')
   }
   sh.exec('git pull')
   // icon包解压到工程目录,覆盖
@@ -23,7 +23,7 @@ const _init = (filePath, commit = '新增icon') => {
   // master
   const currentBranch = getCurrentBranch()
   if (currentBranch !== 'master') {
-    logger.fatal('确保你处于master分支')
+    logger.fatalAndExit('确保你处于master分支')
   }
 
   logger.info('正在推送代码到origin...')

--- a/js/publish/index.js
+++ b/js/publish/index.js
@@ -17,7 +17,7 @@ async function init (tag, user, branch = 'master') {
   // 去对应目录解压backup中的备份
   if (tag) {
     await rollback(tag, branch)
-    online(user)
+    await online(user)
     postOnline(user)
     return
   }
@@ -37,7 +37,7 @@ async function init (tag, user, branch = 'master') {
   await confirm(`打包${branch}分支`)
   build(branch)
   await confirm(branch !== 'master' ? '灰度上线' : '上线')
-  online(user)
+  await online(user)
   postOnline(user, true)
 
   process.on('exit', function () {

--- a/js/test/preview.js
+++ b/js/test/preview.js
@@ -7,7 +7,7 @@ function preview (testBranch) {
   logger.info('>>>>>>>>>> 测试部署前检测')
   // 检测dev机
   if (!sh.pwd().startsWith(DEV_PROJECT_PATH)) {
-    logger.fatal(`确保处于test机器 ${DEV_PROJECT_PATH}`)
+    logger.fatalAndExit(`确保处于test机器 ${DEV_PROJECT_PATH}`)
   }
   commonPreview(testBranch)
 }


### PR DESCRIPTION
配合后端新发布脚本修改，影响到**灰度/全量**的发布。主要改动有:
1. 灰度/全量发布，模板文件会统一放到`gate`上(之前是直接同步到各个后端项目所在的机器)
2. 添加 `本次发布是否跟后端相关?(后端需不需要发版本)` 确认，如果是和后台无关的前端分支发布，`gmfe`  会调用一次 `gmdeploy`，把模板同步到各个机器。如果涉及到后端，后端发布时会自己调用 `gmdeploy`，这样就能保证前后端版本一致

备注：
目前 `gmdeploy` 尚不支持 `admin/yunguanjia`  的模板同步，所以这两个还是按照老的方式同步到后端机器。